### PR TITLE
refactor: 首页改版 | MINOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,31 @@ theme: sea
 
 ```yml
 menu:
-  - name: # 名称
-    url: # 链接
+  - name: Posts # 名称
+    url: /articles/ # 链接
 ```
 
-### 首页个人信息模块
+### 首页配置
 
 ```yml
-hero:
-  enable: false # 默认不展示
-  name: # 名称
-  intro: # 个人简介
+home:
+  hero:
+    name: # 名称
+    intro: # 个人简介
+    avatar: # 头像
+  posts: recent | recommend # recent: 最新文章 | recommend: 推荐文章
+```
+
+### 所有文章页
+
+> 因主页只展示（最近的 5 条 或者 推荐的 5 条）文章，所以自定义一个文章页，可展示所有的文章，支持分页。
+> 在菜单上配置 `/articles/` 路由即可，也可以自定义路径，注意切勿设置关键词 `posts` ，会出现问题。
+
+```yml
+articles:
+  path: '' # 路由，默认为 articles
+  per_page: 10 # 分页数
+  order_by: -date # 文章排序
 ```
 
 ### 评论

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,16 @@
-hero:
-  enable: false
-  name: # 名称
-  intro: # 个人简介
+# 首页配置
+home:
+  hero:
+    name: # 名称
+    intro: # 个人简介
+    avatar: # 头像
+  posts: recent | recommend # recent: 最新文章 | recommend: 推荐文章
+
+# 所有文章
+articles:
+  path: '' # 路由，默认为 articles
+  per_page: 10 # 分页数
+  order_by: -date # 文章排序
 
 # 菜单栏
 menu:

--- a/example/_config.sea.yml
+++ b/example/_config.sea.yml
@@ -1,11 +1,19 @@
-hero:
-  enable: true
-  name: Hexo Theme Sea
-  intro: Hexo Theme Sea is a simple and elegant Hexo blog theme with built-in support for internationalization, light and dark modes, customizable themes, and seamless integration of comments (Waline, Giscus) and search (Algolia).
+
+home:
+  hero:
+    name: Hexo Theme Sea
+    intro: Hexo Theme Sea is a simple and elegant Hexo blog theme with built-in support for internationalization, light and dark modes, customizable themes, and seamless integration of comments (Waline, Giscus) and search (Algolia).
+    avatar: logo.svg
+  posts: recent
+
+articles:
+  path: ''
+  per_page: 10
+  order_by: -date
 
 menu:
-  - name: Home
-    url: /
+  - name: Posts
+    url: /articles/
   - name: Categories
     url: /categories/
   - name: Tags

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,7 @@
     "hexo-generator-index": "^3.0.0",
     "hexo-generator-tag": "^2.0.0",
     "hexo-math": "^5.0.0",
+    "hexo-pagination": "^4.0.0",
     "hexo-renderer-ejs": "^2.0.0",
     "hexo-renderer-marked": "^6.0.0",
     "hexo-renderer-stylus": "^3.0.0",

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1,3 +1,8 @@
+home:
+  recommendedPosts: Recommended posts
+  recentPosts: Recent posts
+  allPosts: All Posts
+
 page:
   contents: Table of contents
   categories: Categories

--- a/languages/zh.yml
+++ b/languages/zh.yml
@@ -1,3 +1,8 @@
+home:
+  recommendedPosts: 推荐文章
+  recentPosts: 最近文章
+  allPosts: 所有文章
+
 page:
   contents: 目录
   categories: 分类

--- a/layout/_partial/main/hero.njk
+++ b/layout/_partial/main/hero.njk
@@ -1,20 +1,27 @@
 <section id="sea-hero-info">
-  <h1>{{ theme.hero.name }}</h1>
-
-  <p class="sea-hero-info__intro">{{ theme.hero.intro }}</p>
-
-  <div class="sea-hero-info__links">
-    {% for item in theme.socialLink %}
-      <a
-        class="sea-hero-info__link-item"
-        {% if item.link.startsWith("http") %}
-          target="_blank"
-        {% endif %}
-        href="{{ url_for(item.link) }}"
-      >
-        {{ item.name }}
-      </a>
-      <span class="sea-hero-info__dot">·</span>
-    {% endfor %}
+  <div class="sea-hero-info__left">
+    <h1 class="sea-hero-name">{{ theme.home.hero.name }}</h1>
+    <p class="sea-hero-info__intro">{{ theme.home.hero.intro }}</p>
+    <div class="sea-hero-info__links">
+      {% for item in theme.socialLink %}
+        <a
+          class="sea-hero-info__link-item"
+          {% if item.link.startsWith("http") %}
+            target="_blank"
+          {% endif %}
+          href="{{ url_for(item.link) }}"
+        >
+          {{ item.name }}
+        </a>
+        <span class="sea-hero-info__dot">·</span>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="sea-hero-info__right">
+    <img
+      class="sea-hero-info__avatar"
+      src="{{ theme.home.hero.avatar }}"
+      alt="{{ theme.home.hero.name }}"
+    />
   </div>
 </section>

--- a/layout/articles.njk
+++ b/layout/articles.njk
@@ -1,0 +1,3 @@
+{{ partial('_partial/post/post_list', {post_list: page.posts.toArray()}) }}
+
+{{ partial('_partial/main/pagination') }}

--- a/layout/index.njk
+++ b/layout/index.njk
@@ -1,7 +1,21 @@
-{% if theme.hero.enable %}
-  {{ partial('_partial/main/hero') }}
+{{ partial('_partial/main/hero') }}
+
+{% if theme.home.posts == 'recommend' %}
+  <h2 class="sea-index-title">
+    {{ __('home.recommendedPosts') }}
+  </h2>
+  {{ partial('_partial/post/post_list', {post_list: recommendedPosts}) }}
+{% elif theme.home.posts == 'recent' %}
+  <h2 class="sea-index-title">
+    {{ __('home.recentPosts') }}
+  </h2>
+  {{ partial('_partial/post/post_list', {post_list: recentPosts}) }}
+{% else %}
 {% endif %}
 
-{{ partial('_partial/post/post_list', {post_list: page.posts.toArray()}) }}
-
-{{ partial('_partial/main/pagination') }}
+<div class="sea-index-all-posts">
+  <a class="sea-index-all-posts__link" href="{{ url_for("/articles") }}">
+    {{ __('home.allPosts') }}
+    {{ partial('svg/arrow_right') }}
+  </a>
+</div>

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -1,0 +1,9 @@
+hexo.extend.filter.register('template_locals', locals => {
+  const allPosts = locals.site.posts.sort('-date').toArray(); // 按日期降序排序
+  const recommendedPosts = allPosts.filter(post => post.recommend === true); // 筛选推荐文章
+
+  // 将结果保存到 locals 中，供模板使用
+  locals.recommendedPosts = recommendedPosts.slice(0, 5);
+  locals.recentPosts = allPosts.slice(0, 5);
+  return locals;
+});

--- a/scripts/page.js
+++ b/scripts/page.js
@@ -1,3 +1,5 @@
+const pagination = require("hexo-pagination");
+
 hexo.extend.generator.register('tags', function () {
   return {
     path: 'tags/index.html',
@@ -18,4 +20,19 @@ hexo.extend.generator.register('categories', function () {
       comment: false
     }
   };
+});
+
+hexo.extend.generator.register('articles', function (locals) {
+  const themeConfig = hexo.theme.config;
+  const path = themeConfig.articles.path || 'articles'; // 默认路径为 'articles'
+  const perPage = themeConfig.articles.per_page || 10; // 每页文章数
+  const orderBy = themeConfig.articles.order_by || '-date'; // 默认按日期降序排序
+
+  const posts = locals.posts.sort(orderBy);
+
+  return pagination(path, posts, {
+    perPage: perPage,
+    layout: ['articles'],
+    data: {},
+  });
 });

--- a/source/css/media.css
+++ b/source/css/media.css
@@ -84,6 +84,10 @@
     left: 1.2rem;
   }
 
+  .sea-hero-info__right {
+    display: none;
+  }
+
   .sea-prev-next-wrapper .prev,
   .sea-prev-next-wrapper .next {
     width: 100%;

--- a/source/css/partial/hero.css
+++ b/source/css/partial/hero.css
@@ -1,3 +1,26 @@
+#sea-hero-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.sea-hero-info__left {
+  flex: 1;
+}
+
+.sea-hero-info__right {
+  width: 12.5rem;
+}
+
+.sea-hero-info__avatar {
+  width: 100%;
+}
+
+.sea-hero-name {
+  font-size: 1.8rem;
+}
+
 .sea-hero-info__intro {
   font-size: 1.125rem;
   line-height: 1.5rem;

--- a/source/css/partial/index.css
+++ b/source/css/partial/index.css
@@ -1,3 +1,11 @@
+.sea-index-title {
+  font-size: 1.8rem;
+  margin-top: 3rem;
+  margin-bottom: .5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--sea-color-divider);
+}
+
 .sea-post-item {
   position: relative;
   padding: 1rem 0;
@@ -53,4 +61,19 @@
 .sea-post-item .sea-post-meta .sea-svg-icon {
   width: .875rem;
   height: .875rem;
+}
+
+.sea-index-all-posts {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.sea-index-all-posts .sea-svg-icon {
+  width: .875rem;
+  height: .875rem;
+}
+
+.sea-index-all-posts:hover .sea-index-all-posts__link {
+  color: var(--sea-color-primary);
 }


### PR DESCRIPTION
## 首页改版
> 分为 个人信息 和 文章展示 两个模块

### 个人信息
可展示 名称、个人简介、头像、社交链接等信息

### 文章展示
可配置展示 ”最近文章“ 或者 ”推荐文章“ 的 5 条数据
注意：展示的推荐文章需要在文章的 `Front-matter` 中加上 `recommend: true`